### PR TITLE
Bugfix/no opener referer empty property

### DIFF
--- a/TestSite.V15/appsettings.json
+++ b/TestSite.V15/appsettings.json
@@ -40,9 +40,5 @@
   },
   "UmbNav": {
     "DisableTelemetry": true
-  },
-  "ConnectionStrings": {
-    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
-    "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
   }
 }

--- a/TestSite.V15/appsettings.json
+++ b/TestSite.V15/appsettings.json
@@ -39,6 +39,10 @@
     }
   },
   "UmbNav": {
-    "DisableTelemetry":  true
+    "DisableTelemetry": true
+  },
+  "ConnectionStrings": {
+    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
+    "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
   }
 }

--- a/Umbraco.Community.UmbNav.Core/Services/UmbNavMenuBuilderService .cs
+++ b/Umbraco.Community.UmbNav.Core/Services/UmbNavMenuBuilderService .cs
@@ -86,7 +86,7 @@ public class UmbNavMenuBuilderService : IUmbNavMenuBuilderService
 
                 if (children.Any())
                 {
-                    var childItems = BuildMenu(children, level + 1).ToList();
+                    var childItems = BuildMenu(children, level + 1, removeNoopener, removeNoreferrer).ToList();
                     if (!children.Equals(childItems))
                     {
                         children = childItems;

--- a/Umbraco.Community.UmbNav.Core/Services/UmbNavMenuBuilderService .cs
+++ b/Umbraco.Community.UmbNav.Core/Services/UmbNavMenuBuilderService .cs
@@ -70,8 +70,8 @@ public class UmbNavMenuBuilderService : IUmbNavMenuBuilderService
                     {
                         item.Content = umbracoContent;
                         umbracoContent.Key.Equals(currentPublishedContentKey).IfTrue(() => item.IsActive = true);
-                        removeNoopener.IfTrue(() => item.Noopener = null);
-                        removeNoreferrer.IfTrue(() => item.Noreferrer = null);
+                        item.Noopener = removeNoopener || string.IsNullOrEmpty(item.Noopener) ? default : item.Noopener;
+                        item.Noreferrer = removeNoreferrer || string.IsNullOrEmpty(item.Noreferrer) ? default : item.Noreferrer;
                         string.IsNullOrWhiteSpace(item.Name).IfTrue(() => umbracoContent.Name(currentCulture));
                     }
                     else

--- a/Umbraco.Community.UmbNav/src/manifest.ts
+++ b/Umbraco.Community.UmbNav/src/manifest.ts
@@ -85,11 +85,11 @@ const umbNavPropertyEditorUiManifest: ManifestPropertyEditorUi = {
                 },
                 {
                      alias : "hideNoopener",
-                     value : false
+                     value : null
                 },
                 {
                      alias : "hideNoreferrer",
-                     value : false
+                     value: null
                 },
                  {
                      alias : "maxDepth",

--- a/Umbraco.Community.UmbNav/src/umbnav-group.ts
+++ b/Umbraco.Community.UmbNav/src/umbnav-group.ts
@@ -95,7 +95,7 @@ export class UmbNavGroup extends UmbElementMixin(LitElement) {
 
     @property({type: Array, attribute: false})
     public get value(): ModelEntryType[] {
-        return this._value ?? [];
+        return this._value || [];
     }
 
     @state()


### PR DESCRIPTION
A few fixes here:
- Noopener and Noreferer options were not pass into the items
- Change Noopener and Noreferer default value to null because they are string values instead of boolean
- Change `this._value ?? []` for `this._value || []` because after saving the document with no items in the navigation property an empty string is saved there for `this._value ?? []` return `""` but `this._value || []` return `[]` 
![onSave](https://github.com/user-attachments/assets/a76d9495-dd9b-4485-b346-cdfb3ec9a4c9)

