### PR TITLE
fix #41 - UmbNav Item Name Now Updates with Content Node Name

### DIFF
--- a/Umbraco.Community.UmbNav/src/components/umbnav-group/umbnav-group.data.ts
+++ b/Umbraco.Community.UmbNav/src/components/umbnav-group/umbnav-group.data.ts
@@ -78,7 +78,7 @@ export async function generateUmbNavLink(context: UmbControllerHost, item: Model
                     return {
                         ...item,
                         icon: await itemDataResolver.getIcon(),
-                        name: item.name,
+                        name: documentItem.variants[0].name,
                         description: await getDocumentUrl(context, item.contentKey as Guid),
                     };
                 }


### PR DESCRIPTION
Solution
Updated generateUmbNavLink in umbnav-group.data.ts:
For document items, the nav item’s name is now always set to documentItem.variants[0].name, ensuring it reflects the latest name from the content node.

How to Test
Change the name of a content node in Umbraco.
Verify that the corresponding UmbNav item’s name updates accordingly in the navigation.