### PR TITLE
[AMEND] Rename JSON property from 'description' to 'menuitemdescription'

### DIFF
--- a/Umbraco.Community.UmbNav.Core/Migrations/UmbNavLegacyModelMigration.cs
+++ b/Umbraco.Community.UmbNav.Core/Migrations/UmbNavLegacyModelMigration.cs
@@ -298,7 +298,7 @@ internal sealed class UmbNavLegacyModelMigration : AsyncPackageMigrationBase
         [JsonPropertyName("icon")]
         public string? Icon { get; set; }
 
-        [JsonPropertyName("description")]
+        [JsonPropertyName("menuitemdescription")]
         public string? Description { get; set; }
 
         [JsonPropertyName("target")]


### PR DESCRIPTION
The legacy field for a custom description is actually `menuitemdescription` and not description.