### PR TITLE
Improves GitHub Actions workflows and adds Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  # Monitor NuGet packages
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    target-branch: "develop"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "nuget"
+
+  # Monitor npm packages
+  - package-ecosystem: "npm"
+    directory: "/Umbraco.Community.UmbNav"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    target-branch: "develop"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "npm"
+
+  # Monitor GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    target-branch: "develop"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,6 +3,8 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
+    branches:
+      - develop
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"

--- a/.github/workflows/dotnet-build-prelease.yml
+++ b/.github/workflows/dotnet-build-prelease.yml
@@ -133,12 +133,12 @@ jobs:
           dotnet nuget push ./build.out/Umbraco.Community.UmbNav.Core.${{steps.gitversion.outputs.nuGetVersionV2}}.nupkg --skip-duplicate --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
 
       - name: Create Release
-        uses: "softprops/action-gh-release@v2"
-        with:
-          name: ${{steps.gitversion.outputs.fullSemVer}}
-          tag_name: ${{steps.gitversion.outputs.fullSemVer}}
-          prerelease: true
-          generate_release_notes: true
-          files: |
-            ./build.out/Umbraco.Community.UmbNav.${{steps.gitversion.outputs.nuGetVersionV2}}.nupkg
-            ./build.out/Umbraco.Community.UmbNav.Core.${{steps.gitversion.outputs.nuGetVersionV2}}.nupkg
+        run: |
+          gh release create ${{steps.gitversion.outputs.fullSemVer}} `
+            ./build.out/Umbraco.Community.UmbNav.${{steps.gitversion.outputs.nuGetVersionV2}}.nupkg `
+            ./build.out/Umbraco.Community.UmbNav.Core.${{steps.gitversion.outputs.nuGetVersionV2}}.nupkg `
+            --title "${{steps.gitversion.outputs.fullSemVer}}" `
+            --prerelease `
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/dotnet-build.stablerelease.yml
+++ b/.github/workflows/dotnet-build.stablerelease.yml
@@ -132,12 +132,11 @@ jobs:
           dotnet nuget push ./build.out/Umbraco.Community.UmbNav.Core.${{steps.gitversion.outputs.nuGetVersionV2}}.nupkg --skip-duplicate --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
 
       - name: Create Release
-        uses: "softprops/action-gh-release@v2"
-        with:
-          name: ${{steps.gitversion.outputs.fullSemVer}}
-          tag_name: ${{steps.gitversion.outputs.fullSemVer}}
-          prerelease: false
-          generate_release_notes: true
-          files: |
-            ./build.out/Umbraco.Community.UmbNav.${{steps.gitversion.outputs.nuGetVersionV2}}.nupkg
-            ./build.out/Umbraco.Community.UmbNav.Core.${{steps.gitversion.outputs.nuGetVersionV2}}.nupkg
+        run: |
+          gh release create ${{steps.gitversion.outputs.semVer}} `
+            ./build.out/Umbraco.Community.UmbNav.${{steps.gitversion.outputs.nuGetVersionV2}}.nupkg `
+            ./build.out/Umbraco.Community.UmbNav.Core.${{steps.gitversion.outputs.nuGetVersionV2}}.nupkg `
+            --title "${{steps.gitversion.outputs.semVer}}" `
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
- Fixes release tag format: Stable releases now use clean semver (4.1.0) instead of build metadata (4.1.0+5)
- Improves release notes generation: Switches from softprops action to gh CLI for better automatic release notes
- Optimizes Claude code review: Only runs on PRs to develop, avoiding redundant reviews on develop→main PRs
- Adds Dependabot configuration: Monitors NuGet, npm, and GitHub Actions targeting develop branch

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
