### PR TITLE
Improves GitHub Actions workflows and adds Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,19 @@ updates:
     labels:
       - "dependencies"
       - "nuget"
+    # Stay on Umbraco v17, only create PRs for security vulnerabilities
+    ignore:
+      # Block all version updates to v18+
+      - dependency-name: "Umbraco.*"
+        versions: [">= 18.0.0"]
+      # Block routine minor/patch updates within v17
+      # Security updates will still be created (they bypass ignore rules)
+      - dependency-name: "Umbraco.*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      # For transitive dependencies: only non-breaking security updates (patch only)
+      - dependency-name: "*"
+        dependency-type: "indirect"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   # Monitor npm packages
   - package-ecosystem: "npm"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,11 +14,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip Dependabot PRs to save API credits
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
- Fixes release tag format: Stable releases now use clean semver (4.1.0) instead of build metadata (4.1.0+5)
- Improves release notes generation: Switches from softprops action to gh CLI for better automatic release notes
- Optimizes Claude code review: Only runs on PRs to develop, avoiding redundant reviews on develop→main PRs
- Adds Dependabot configuration: Monitors NuGet, npm, and GitHub Actions targeting develop branch

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>