### PR TITLE
Allow Empty value 

### DIFF
--- a/Umbraco.Community.UmbNav/src/components/umbnav-property-editor-ui/umbnav-property-editor-ui.ts
+++ b/Umbraco.Community.UmbNav/src/components/umbnav-property-editor-ui/umbnav-property-editor-ui.ts
@@ -18,7 +18,7 @@ export default class UmbNavSorterPropertyEditorUIElement extends UmbFormControlM
         this.addValidator(
             'valueMissing',
             () => this.localize.term('umbnav_requiredMessage'),
-            () => !this.value || this.value.length === 0
+            () => this.mandatory === true && (!this.value || this.value.length === 0)
         );
     }
 
@@ -45,6 +45,9 @@ export default class UmbNavSorterPropertyEditorUIElement extends UmbFormControlM
 
         return <Boolean>this.config?.find(item => item.alias === 'enableToggleAllButton')?.value ?? false;
     }
+
+    @property({ type: Boolean })
+    mandatory?: boolean;
 
     @state()
     expandAll: boolean = false;


### PR DESCRIPTION
Only validate when the property has been marked as mandatory in the doctype 

Fixed #104 