### PR TITLE
Fixes item type and custom edit modal

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 

--- a/TestSite.V17/App_Plugins/TestDivider/register.js
+++ b/TestSite.V17/App_Plugins/TestDivider/register.js
@@ -1,0 +1,41 @@
+// Test extension: Register a "Divider" custom item type with UmbNav
+// This verifies that custom itemTypes are preserved (not falling back to "Title")
+
+const POLL_INTERVAL = 500;
+const MAX_ATTEMPTS = 20;
+
+async function registerDivider() {
+    let attempts = 0;
+
+    const interval = setInterval(async () => {
+        attempts++;
+
+        try {
+            const { UmbNavExtensionRegistry } = await import('/App_Plugins/UmbNav/dist/api.js');
+
+            UmbNavExtensionRegistry.registerItemType({
+                type: 'divider',
+                label: 'Add Divider',
+                icon: 'icon-navigation-horizontal',
+                allowChildren: false,
+                defaultValues: {
+                    name: '---',
+                    icon: 'icon-navigation-horizontal',
+                    itemType: 'divider'
+                }
+            });
+
+            console.log('[TestDivider] Registered "divider" custom item type');
+            clearInterval(interval);
+        } catch (e) {
+            if (attempts >= MAX_ATTEMPTS) {
+                console.warn('[TestDivider] Could not register divider type - UmbNav API not available');
+                clearInterval(interval);
+            }
+        }
+    }, POLL_INTERVAL);
+}
+
+registerDivider();
+
+export default {};

--- a/TestSite.V17/App_Plugins/TestDivider/umbraco-package.json
+++ b/TestSite.V17/App_Plugins/TestDivider/umbraco-package.json
@@ -1,0 +1,13 @@
+{
+  "id": "test-divider",
+  "name": "Test Divider",
+  "version": "1.0.0",
+  "extensions": [
+    {
+      "type": "backofficeEntryPoint",
+      "alias": "test.divider.entrypoint",
+      "name": "Test Divider Entry Point",
+      "js": "/App_Plugins/TestDivider/register.js"
+    }
+  ]
+}

--- a/TestSite.V17/Views/Contact.cshtml
+++ b/TestSite.V17/Views/Contact.cshtml
@@ -2,7 +2,7 @@
 @using ContentModels = Umbraco.Cms.Web.Common.PublishedModels
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<ContentModels.Contact>
 @{
-    Layout = "_Master.cshtml";
+    Layout = "master.cshtml";
 }
 
 <partial name="Partials/SectionHeader"/>

--- a/TestSite.V17/Views/Partials/Navigation/UmbNavMain.cshtml
+++ b/TestSite.V17/Views/Partials/Navigation/UmbNavMain.cshtml
@@ -24,6 +24,10 @@
                     </div>
                 </div>
             }
+            else if (umbNavItem.ItemType == "divider")
+            {
+                <strong style="color: #fff"> | </strong>
+            }
             else
             {
                 @* <a class="nav-link @(UmbracoContext?.PublishedRequest?.PublishedContent != null && umbNavItem.IsActive(UmbracoContext?.PublishedRequest?.PublishedContent) ? "nav-link--active" : null)" href="@umbNavItem.Url()">@umbNavItem.Name</a> *@

--- a/TestSite.V17/Views/contentPage.cshtml
+++ b/TestSite.V17/Views/contentPage.cshtml
@@ -1,7 +1,7 @@
 ﻿@using ContentModels = Umbraco.Cms.Web.Common.PublishedModels
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<ContentModels.ContentPage>
 @{
-    Layout = "_Master.cshtml";
+    Layout = "master.cshtml";
 }
 
 <partial name="Partials/SectionHeader" />

--- a/TestSite.V17/Views/home.cshtml
+++ b/TestSite.V17/Views/home.cshtml
@@ -1,6 +1,6 @@
-﻿@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Home>
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Home>
 @{
-    Layout = "_Master.cshtml";
+    Layout = "master.cshtml";
     var backgroundImage = Model.HeroBackgroundImage != null ? Model.HeroBackgroundImage.Url() : String.Empty;
 }
 <section class="section section--full-height background-image-full overlay overlay--dark section--content-center section--thick-border"

--- a/TestSite.V17/Views/master.cshtml
+++ b/TestSite.V17/Views/master.cshtml
@@ -22,7 +22,7 @@
     <body class="frontpage theme-font-@(home.Font) theme-color-@(home.ColorTheme)">
         <div class="mobile-nav">
             <nav class="nav-bar">
-                <partial name="Partials/Navigation/TopNavigation"/>
+                <partial name="Partials/Navigation/UmbNavMain"/>
             </nav>
         </div>
 
@@ -42,7 +42,7 @@
             </div>
 
             <nav class="nav-bar top-nav">
-                <partial name="Partials/Navigation/TopNavigation"/>
+                <partial name="Partials/Navigation/UmbNavMain"/>
             </nav>
 
             <div class="mobile-nav-handler">

--- a/TestSite.V17/Views/people.cshtml
+++ b/TestSite.V17/Views/people.cshtml
@@ -1,6 +1,6 @@
 ﻿@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<People>
 @{
-    Layout = "_Master.cshtml";
+    Layout = "master.cshtml";
 }
 @{
     void SocialLink(string content, string service)

--- a/TestSite.V17/uSync/v17/Content/home-5.config
+++ b/TestSite.V17/uSync/v17/Content/home-5.config
@@ -18,7 +18,7 @@
       <Published Culture="es">true</Published>
     </Published>
     <Schedule />
-    <Template Key="b62144fa-cb6f-4c09-aad4-5d8dc0cfc208">home</Template>
+    <Template Key="ce847acd-a699-4588-8715-04ae7548d988">home</Template>
   </Info>
   <Properties>
     <bodyText>
@@ -288,11 +288,35 @@
         "noopener": "",
         "image": [],
         "children": [],
-        "depth": 2
+        "depth": 2,
+        "unique": "ce760fcd-89f2-4e3d-8dc3-00e4450640c6"
       }
     ],
     "depth": 1,
     "unique": "178a9023-c8bc-4a41-8dfb-ede44b0e817e"
+  },
+  {
+    "key": "fba1329c-1dcf-4606-b090-e473d33cddf4",
+    "name": "---",
+    "icon": "icon-navigation-horizontal",
+    "itemType": "divider",
+    "url": null,
+    "udi": null,
+    "contentKey": null,
+    "anchor": null,
+    "published": null,
+    "target": null,
+    "customClasses": null,
+    "description": null,
+    "hideLoggedIn": false,
+    "hideLoggedOut": false,
+    "includeChildNodes": false,
+    "noopener": null,
+    "noreferrer": null,
+    "image": [],
+    "children": [],
+    "allowChildren": false,
+    "depth": 1
   }
 ]]]></Value>
       <Value Culture="es"><![CDATA[[

--- a/TestSite.V17/uSync/v17/ContentTypes/home.config
+++ b/TestSite.V17/uSync/v17/ContentTypes/home.config
@@ -17,7 +17,7 @@
     <Compositions />
     <DefaultTemplate>home</DefaultTemplate>
     <AllowedTemplates>
-      <Template Key="b62144fa-cb6f-4c09-aad4-5d8dc0cfc208">home</Template>
+      <Template Key="ce847acd-a699-4588-8715-04ae7548d988">home</Template>
     </AllowedTemplates>
   </Info>
   <Structure>

--- a/TestSite.V17/uSync/v17/Templates/home.config
+++ b/TestSite.V17/uSync/v17/Templates/home.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Template Key="b62144fa-cb6f-4c09-aad4-5d8dc0cfc208" Alias="home" Level="2">
+<Template Key="ce847acd-a699-4588-8715-04ae7548d988" Alias="home" Level="2">
   <Name>Home</Name>
   <Parent>master</Parent>
 </Template>

--- a/Umbraco.Community.UmbNav.Core.Tests/Models/UmbNavItemTests.cs
+++ b/Umbraco.Community.UmbNav.Core.Tests/Models/UmbNavItemTests.cs
@@ -129,7 +129,7 @@ public class UmbNavItemTests
         var item = JsonSerializer.Deserialize<UmbNavItem>(json);
 
         Assert.NotNull(item);
-        Assert.Equal(Enum.Parse<UmbNavItemType>(itemTypeString), item.ItemType);
+        Assert.Equal(itemTypeString, item.ItemType);
     }
 
     [Fact]
@@ -273,7 +273,7 @@ public class UmbNavItemTests
     }
 
     [Fact]
-    public void Published_DefaultsToFalse()
+    public void Published_DefaultsToNull()
     {
         var item = new UmbNavItem
         {
@@ -281,7 +281,7 @@ public class UmbNavItemTests
             ItemType = UmbNavItemType.External
         };
 
-        Assert.False(item.Published);
+        Assert.Null(item.Published);
     }
 
     [Fact]
@@ -330,5 +330,38 @@ public class UmbNavItemTests
         };
 
         Assert.False(item.HideLoggedOut);
+    }
+
+    [Fact]
+    public void Deserialize_WithCustomItemType_DeserializesCorrectly()
+    {
+        var json = """
+            {
+                "key": "11111111-1111-1111-1111-111111111111",
+                "name": "Divider",
+                "itemType": "divider"
+            }
+            """;
+
+        var item = JsonSerializer.Deserialize<UmbNavItem>(json);
+
+        Assert.NotNull(item);
+        Assert.Equal("divider", item.ItemType);
+        Assert.Equal("Divider", item.Name);
+    }
+
+    [Fact]
+    public void Serialize_WithCustomItemType_SerializesCorrectly()
+    {
+        var item = new UmbNavItem
+        {
+            Key = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            Name = "Divider",
+            ItemType = "divider"
+        };
+
+        var json = JsonSerializer.Serialize(item);
+
+        Assert.Contains("\"itemType\":\"divider\"", json);
     }
 }

--- a/Umbraco.Community.UmbNav.Core/Extensions/UmbNavItemExtensions.cs
+++ b/Umbraco.Community.UmbNav.Core/Extensions/UmbNavItemExtensions.cs
@@ -12,7 +12,7 @@ namespace Umbraco.Community.UmbNav.Core.Extensions
         public static IHtmlContent GetLinkHtml(this UmbNavItem item, string? cssClass = null, string? id = null, string? culture = null, UrlMode mode = UrlMode.Default, string labelTagName = "span", object? htmlAttributes = null, string? activeClass = null)
         {
             var htmlAttributesConverted = HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes);
-            var tagBuilder = item.ItemType == UmbNavItemType.Title
+            var tagBuilder = string.Equals(item.ItemType, UmbNavItemType.Title, StringComparison.OrdinalIgnoreCase)
                 ? new TagBuilder(labelTagName)
                 : new TagBuilder("a");
 
@@ -40,7 +40,7 @@ namespace Umbraco.Community.UmbNav.Core.Extensions
 
             tagBuilder.MergeAttributes(htmlAttributesConverted);
 
-            if (item.ItemType == UmbNavItemType.Title)
+            if (string.Equals(item.ItemType, UmbNavItemType.Title, StringComparison.OrdinalIgnoreCase))
             {
                 return tagBuilder;
             }

--- a/Umbraco.Community.UmbNav.Core/Migrations/UmbNavLegacyModelMigration.cs
+++ b/Umbraco.Community.UmbNav.Core/Migrations/UmbNavLegacyModelMigration.cs
@@ -198,8 +198,7 @@ internal sealed class UmbNavLegacyModelMigration : AsyncPackageMigrationBase
     // Add this static readonly field to cache the JsonSerializerOptions instance
     private static readonly JsonSerializerOptions CachedJsonSerializerOptions = new JsonSerializerOptions
     {
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        Converters = { new JsonStringEnumConverter() }
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 
     public static bool TryTransformLegacyValue(ILogger logger, string legacyValue, out string newValue)
@@ -255,7 +254,7 @@ internal sealed class UmbNavLegacyModelMigration : AsyncPackageMigrationBase
         };
     }
 
-    private static UmbNavItemType MapItemType(OldUmbNavItemType oldItemType) => oldItemType switch
+    private static string MapItemType(OldUmbNavItemType oldItemType) => oldItemType switch
     {
         OldUmbNavItemType.Link => UmbNavItemType.External,
         OldUmbNavItemType.Content => UmbNavItemType.Document,

--- a/Umbraco.Community.UmbNav.Core/Models/UmbNavItem.cs
+++ b/Umbraco.Community.UmbNav.Core/Models/UmbNavItem.cs
@@ -21,9 +21,8 @@ public class UmbNavItem
     [JsonPropertyName("icon")]
     public string? Icon { get; set; }
 
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     [JsonPropertyName("itemType")]
-    public UmbNavItemType ItemType { get; set; }
+    public string ItemType { get; set; } = string.Empty;
 
     [JsonPropertyName("contentKey")]
     public Guid? ContentKey { get; set; }
@@ -32,7 +31,7 @@ public class UmbNavItem
     public string? Anchor { get; set; }
 
     [JsonPropertyName("published")]
-    public bool Published { get; set; }
+    public bool? Published { get; set; }
 
     [JsonPropertyName("children")]
     public IEnumerable<UmbNavItem>? Children { get; set; }

--- a/Umbraco.Community.UmbNav.Core/Models/UmbNavItemType.cs
+++ b/Umbraco.Community.UmbNav.Core/Models/UmbNavItemType.cs
@@ -1,15 +1,9 @@
-﻿using System.Runtime.Serialization;
-
 namespace Umbraco.Community.UmbNav.Core.Models;
 
-public enum UmbNavItemType
+public static class UmbNavItemType
 {
-    [EnumMember(Value = "document")]
-    Document,
-    [EnumMember(Value = "external")]
-    External,
-    [EnumMember(Value = "media")]
-    Media,
-    [EnumMember(Value = "title")]
-    Title
+    public const string Document = "Document";
+    public const string External = "External";
+    public const string Media = "Media";
+    public const string Title = "Title";
 }

--- a/Umbraco.Community.UmbNav.Core/Services/UmbNavMenuBuilderService.cs
+++ b/Umbraco.Community.UmbNav.Core/Services/UmbNavMenuBuilderService.cs
@@ -161,7 +161,7 @@ public class UmbNavMenuBuilderService : IUmbNavMenuBuilderService
         }
 
         var contentKey = item.ContentKey.Value;
-        var umbracoContent = item.ItemType == UmbNavItemType.Media
+        var umbracoContent = string.Equals(item.ItemType, UmbNavItemType.Media, StringComparison.OrdinalIgnoreCase)
             ? _publishedMediaCache.GetById(contentKey)
             : _publishedContentCache.GetById(contentKey);
 

--- a/Umbraco.Community.UmbNav.Core/TagHelpers/UmbnavItemTagHelper.cs
+++ b/Umbraco.Community.UmbNav.Core/TagHelpers/UmbnavItemTagHelper.cs
@@ -51,7 +51,7 @@ namespace Umbraco.Community.UmbNav.Core.TagHelpers
         /// <summary>
         /// Determines if the current item is a label (non-link) item.
         /// </summary>
-        protected virtual bool IsLabel => MenuItem?.ItemType == UmbNavItemType.Title;
+        protected virtual bool IsLabel => string.Equals(MenuItem?.ItemType, UmbNavItemType.Title, StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// Gets the tag name to render for this item.

--- a/Umbraco.Community.UmbNav/src/components/umbnav-group/umbnav-group.modals.ts
+++ b/Umbraco.Community.UmbNav/src/components/umbnav-group/umbnav-group.modals.ts
@@ -58,7 +58,7 @@ export async function openSettingsModal(
         let item: ModelEntryType = {
             key: key,
             name: '',
-            itemType: 'title',
+            itemType: 'Title',
             icon: 'icon-tag',
             published: true,
             udi: null,
@@ -109,7 +109,7 @@ export async function openVisibilityModal(
         let item: ModelEntryType = {
             key: key,
             name: '',
-            itemType: 'title',
+            itemType: 'Title',
             icon: 'icon-tag',
             published: true,
             udi: null,

--- a/Umbraco.Community.UmbNav/src/components/umbnav-group/umbnav-group.ts
+++ b/Umbraco.Community.UmbNav/src/components/umbnav-group/umbnav-group.ts
@@ -413,7 +413,7 @@ export class UmbNavGroup extends UmbElementMixin(LitElement) {
             noreferrer: defaults.noreferrer ?? null,
             image: defaults.image ?? [],
             children: [],
-            allowChildren: registration.allowChildren
+            allowChildren: registration.allowChildren ?? true
         };
         this.#addItem(newItem);
     }

--- a/Umbraco.Community.UmbNav/src/components/umbnav-item/umbnav-item.styles.ts
+++ b/Umbraco.Community.UmbNav/src/components/umbnav-item/umbnav-item.styles.ts
@@ -55,14 +55,17 @@ export const UmbNavItemStyles = [
 
             #name {
                 font-weight: 700;
-                cursor: pointer;
             }
-            
+
             #description,
             #url {
                 color: #515054;
                 font-size: 12px;
                 line-height: 1.5em;
+            }
+
+            .name {
+                cursor: pointer;
             }
 
             .name:hover {

--- a/Umbraco.Community.UmbNav/src/components/umbnav-item/umbnav-item.ts
+++ b/Umbraco.Community.UmbNav/src/components/umbnav-item/umbnav-item.ts
@@ -76,6 +76,9 @@ export class UmbNavItem extends UmbElementMixin(LitElement) {
     @property({ type: Number, reflect: true })
     currentDepth: number = -1;
 
+    @property({ type: Boolean, reflect: true })
+    editable: boolean = true;
+
     /**
      * The full item data for extension access.
      */
@@ -294,7 +297,9 @@ export class UmbNavItem extends UmbElementMixin(LitElement) {
         return html`
             <div id="name">
                 ${this.renderExtensionSlots('before-name')}
-                <span class="name" @click=${() => this.editNode(this.key)}>${this.name}</span>
+                ${this.editable
+                    ? html`<span class="name" @click=${() => this.editNode(this.key)}>${this.name}</span>`
+                    : html`<span class="name-static">${this.name}</span>`}
                 ${this.hideIncludesChildNodes && this.hideIncludesChildNodes ? html` <span class="umbnav-badge">Includes Child Nodes</span>` : ''}
                 ${this.enableMediaPicker ? html`<span class="image" @click=${() => this.addImage(this.key)}>${this.hasImage ? html`<umb-icon name="picture"></umb-icon>` : ''}</span>` : ''}
                 ${this.enableVisibility && this.hideLoggedOut ? html`<span class="image" @click=${() => this.toggleVisibility(this.key)}>${this.hideLoggedOut ? html`<umb-icon name="lock"></umb-icon>` : ''}</span>` : ''}
@@ -345,10 +350,12 @@ export class UmbNavItem extends UmbElementMixin(LitElement) {
                 </uui-button>
             ` : ''}
 
-            <uui-button look="secondary" label=${this.localize.term('umbnav_buttonsEdit')}
-                        @click=${() => this.editNode(this.key)}>
-                <uui-icon name="edit"></uui-icon>
-            </uui-button>
+            ${this.editable ? html`
+                <uui-button look="secondary" label=${this.localize.term('umbnav_buttonsEdit')}
+                            @click=${() => this.editNode(this.key)}>
+                    <uui-icon name="edit"></uui-icon>
+                </uui-button>
+            ` : ''}
 
             <uui-button look="secondary" label=${this.localize.term('umbnav_buttonsDelete')}
                         @click=${() => this.requestDelete()}>

--- a/Umbraco.Community.UmbNav/src/modals/settings-item-modal-element.ts
+++ b/Umbraco.Community.UmbNav/src/modals/settings-item-modal-element.ts
@@ -135,7 +135,7 @@ export class UmbNavModalElement extends
                     )}
 
                     ${when(
-                            !this.includeChildNodesToggle && this.data?.itemType === 'document',
+                            !this.includeChildNodesToggle && this.data?.itemType === 'Document',
                             () => html`${this.#renderIncludeChildNodesToggle()}`,
                     )}
 				</uui-box>

--- a/Umbraco.Community.UmbNav/src/modals/text-item-modal-element.ts
+++ b/Umbraco.Community.UmbNav/src/modals/text-item-modal-element.ts
@@ -38,7 +38,7 @@ export class UmbNavModalElement extends
                 name: this.value?.name ?? '',
                 url: null,
                 icon: 'icon-tag',
-                itemType: 'title',
+                itemType: 'Title',
                 udi: null,
                 contentKey: null,
                 anchor: null,

--- a/Umbraco.Community.UmbNav/src/tokens/umbnav.token.ts
+++ b/Umbraco.Community.UmbNav/src/tokens/umbnav.token.ts
@@ -1,7 +1,7 @@
 
 export type Guid = '' |`${string}-${string}-${string}-${string}-${string}`;
 export type GuidUdi = '' | `umb://document/${string}` | `umb://media/${string}`
-export type UmbNavLinkPickerLinkType = 'title' | 'nolink' | 'Document' | 'External' | 'Media' | 'Title' | 'NoLink';
+export type UmbNavLinkPickerLinkType = string;
 export type ModelEntryType = {
     key: Guid | null | undefined,
     name: string | null | undefined,

--- a/Umbraco.Community.UmbNav/tests/mandatory-blocks-empty-save.spec.ts
+++ b/Umbraco.Community.UmbNav/tests/mandatory-blocks-empty-save.spec.ts
@@ -1,0 +1,37 @@
+import { expect  } from '@playwright/test';
+import { test, ConstantHelper } from "@umbraco/playwright-testhelpers";
+
+const contentName = 'Node'; // Uses 'node' document type where UmbNav is mandatory
+
+test.beforeEach(async ({ umbracoUi }) => {
+    await umbracoUi.goToBackOffice();
+    await umbracoUi.login.enterEmail(ConstantHelper.testUserCredentials.email);
+    await umbracoUi.login.enterPassword(ConstantHelper.testUserCredentials.password);
+    await umbracoUi.login.clickLoginButton();
+    const tab = umbracoUi.page.getByRole('tab', { name: 'Content' });
+    await expect(tab).toBeVisible();
+    await tab.click();
+});
+
+test.describe("UmbNav Mandatory Property", () => {
+    test('mandatory property blocks saving when empty', async ({ umbracoUi }) => {
+        await umbracoUi.content.goToContentWithName(contentName);
+
+        const editor = umbracoUi.page.locator('umbnav-property-editor-ui');
+        await editor.waitFor({ state: 'visible' });
+
+        // Ensure UmbNav has no items
+        const items = editor.locator('umbnav-item');
+        await expect(items).toHaveCount(0);
+
+        // Attempt to save and publish with empty mandatory UmbNav
+        const saveButton = umbracoUi.page.getByRole('button', { name: 'Save And Publish' });
+        await saveButton.click();
+
+        // Verify validation message appears — the valueMissing validator should
+        // surface "At least one menu item is required."
+        const validationMessage = umbracoUi.page.getByText('At least one menu item is required.');
+        await validationMessage.waitFor({ state: 'visible' });
+        await expect(validationMessage).toBeVisible();
+    });
+});

--- a/Umbraco.Community.UmbNav/tests/optional-allows-empty-save.spec.ts
+++ b/Umbraco.Community.UmbNav/tests/optional-allows-empty-save.spec.ts
@@ -1,0 +1,40 @@
+import { expect  } from '@playwright/test';
+import { test, ConstantHelper } from "@umbraco/playwright-testhelpers";
+
+const contentName = 'Node Single'; // Uses 'node1' document type where UmbNav is optional
+
+test.beforeEach(async ({ umbracoUi }) => {
+    await umbracoUi.goToBackOffice();
+    await umbracoUi.login.enterEmail(ConstantHelper.testUserCredentials.email);
+    await umbracoUi.login.enterPassword(ConstantHelper.testUserCredentials.password);
+    await umbracoUi.login.clickLoginButton();
+    const tab = umbracoUi.page.getByRole('tab', { name: 'Content' });
+    await expect(tab).toBeVisible();
+    await tab.click();
+});
+
+test.describe("UmbNav Optional Property", () => {
+    test('optional property allows saving when empty', async ({ umbracoUi }) => {
+        await umbracoUi.content.goToContentWithName(contentName);
+
+        const editor = umbracoUi.page.locator('umbnav-property-editor-ui');
+        await editor.waitFor({ state: 'visible' });
+
+        // Ensure UmbNav has no items
+        const items = editor.locator('umbnav-item');
+        await expect(items).toHaveCount(0);
+
+        // Save and publish with empty optional UmbNav
+        const saveButton = umbracoUi.page.getByRole('button', { name: 'Save And Publish' });
+        await saveButton.click();
+
+        // Verify no mandatory validation error appears
+        const validationMessage = umbracoUi.page.getByText('At least one menu item is required.');
+        await expect(validationMessage).not.toBeVisible();
+
+        // Verify save succeeded via success notification
+        const successNotification = umbracoUi.page.locator('uui-toast-notification[color="positive"]');
+        await successNotification.waitFor({ state: 'visible', timeout: 10000 });
+        await expect(successNotification).toBeVisible();
+    });
+});


### PR DESCRIPTION
Addresses issues with item type case sensitivity and enhances custom item type edit modal support.

- Corrects an item type case mismatch.
- Introduces support for custom item type edit modals, enabling the registration and utilization of custom modals for editing specific item types.
- Fixes an issue where custom item types were not being correctly preserved, falling back to a default "Title" type.