### PR TITLE
Add support for "VaryByCulture" when migrating

### DIFF
--- a/Umbraco.Community.UmbNav.Core/Migrations/UmbNavLegacyModelMigration.cs
+++ b/Umbraco.Community.UmbNav.Core/Migrations/UmbNavLegacyModelMigration.cs
@@ -150,24 +150,16 @@ internal sealed class UmbNavLegacyModelMigration : AsyncPackageMigrationBase
                     {
                         if (property.PropertyType.PropertyEditorAlias == UmbNavConstants.LegacyEditorAlias)
                         {
-                            var legacyValue = property.GetValue()?.ToString();
-                            if (!string.IsNullOrWhiteSpace(legacyValue))
+                            if (property.PropertyType.VariesByCulture())
                             {
-                                try
+                                foreach (var culture in content.AvailableCultures)
                                 {
-                                    // Example transformation logic; adjust as needed
-                                    var hasTransformed = TryTransformLegacyValue(_logger, legacyValue, out var newValue);
-                                    if (hasTransformed)
-                                    {
-                                        property.SetValue(newValue);
-                                        saveContent = true;
-                                    }
+                                    saveContent |= GetValueAndTryTransform(saveContent, property, culture);
                                 }
-                                catch (Exception ex)
-                                {
-                                    _logger.LogError(ex, "Something went wrong migrating legacy content.{legacyValue}", legacyValue);
-                                }
-
+                            }
+                            else
+                            {
+                                saveContent = GetValueAndTryTransform(saveContent, property, null);
                             }
                         }
                     }
@@ -193,6 +185,31 @@ internal sealed class UmbNavLegacyModelMigration : AsyncPackageMigrationBase
 
         } while (loop);
 
+    }
+
+    private bool GetValueAndTryTransform(bool saveContent, IProperty property, string? culture)
+    {
+        var legacyValue = property.GetValue(culture)?.ToString();
+        if (!string.IsNullOrWhiteSpace(legacyValue))
+        {
+            try
+            {
+                // Example transformation logic; adjust as needed
+                var hasTransformed = TryTransformLegacyValue(_logger, legacyValue, out var newValue);
+                if (hasTransformed)
+                {
+                    property.SetValue(newValue, culture);
+                    saveContent = true;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Something went wrong migrating legacy content.{legacyValue}", legacyValue);
+            }
+
+        }
+
+        return saveContent;
     }
 
     // Add this static readonly field to cache the JsonSerializerOptions instance


### PR DESCRIPTION
**Issue**
UmbNavLegacyModelMigration silently skips all properties on multilingual sites.

**Description**
The legacy migration produces no output on sites with culture-variant UmbNav properties because property.GetValue() is called without a culture argument.

**Root cause**
In ProcessContentType, the value is retrieved as:
```
var legacyValue = property.GetValue()?.ToString();
```
GetValue() with no parameters looks up the invariant value (culture = null). On a multilingual site, UmbNav properties are configured as culture-variant, so all values are stored in umbracoPropertyData with a non-null languageId. There is no invariant row — GetValue() returns null for every property, the if (!string.IsNullOrWhiteSpace(legacyValue)) guard is never entered, and the migration completes silently without transforming any data.

**Fix**
Check property.PropertyType.VariesByCulture() and iterate content.AvailableCultures when true, passing the culture to both GetValue and SetValue.

**Environment**
- Umbraco.Community.UmbNav v4.1.5
- Umbraco CMS v17
- Multilingual site with culture-variant UmbNav properties
- Upgrading from AaronSadler.UmbNav (v3)
