### PR TITLE
fix: wrap long manually entered URLs in menu item display

### DIFF
--- a/Umbraco.Community.UmbNav/src/components/umbnav-item/umbnav-item.styles.ts
+++ b/Umbraco.Community.UmbNav/src/components/umbnav-item/umbnav-item.styles.ts
@@ -64,6 +64,13 @@ export const UmbNavItemStyles = [
                 line-height: 1.5em;
             }
 
+            /* Long manually entered URLs (e.g. with large query strings) have no
+               natural break points, so without this they force the item row wider
+               than the property editor and misalign the "Add Link Item" button. */
+            #url {
+                overflow-wrap: anywhere;
+            }
+
             .name {
                 cursor: pointer;
             }


### PR DESCRIPTION
**Description**

Adds `overflow-wrap: anywhere;` to the `#url` element in `umbnav-item.styles.ts`. Manually entered URLs with no natural break points (typically large query strings) currently render unbroken; because `#info` has `flex-shrink: 0`, the URL forces the item row wider than the property editor, stretching it to double width and misaligning the "Add Link Item" button. With this change the URL wraps inside the row and the layout keeps its normal width.

**Related issues**

Closes #201

**Testing performed**

Verified in the backoffice with a manually entered URL of several hundred characters: the URL now wraps within the item row, the property editor stays single-width, and the "Add Link Item" button remains aligned. Short URLs are unaffected (`overflow-wrap: anywhere` only introduces breaks when overflow would otherwise occur).

**Notes**

`dev/v18` has the identical `#url` rule, so this fix applies there as well.
