### PR TITLE
fix: don't resolve content for external and title items (#204)

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -242,7 +242,7 @@ The migration runs automatically on first startup after upgrading and:
 
 | Old | New |
 |-----|-----|
-| `udi` (string) | `contentKey` (Guid) |
+| `udi` (string) | `contentKey` (Guid) — only for `Document` items; a udi left behind on an external link or label is discarded |
 | `title`/`name` | `name` (title preferred) |
 | `itemType: Link` | `itemType: External` |
 | `itemType: Content` | `itemType: Document` |

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -28,6 +28,22 @@ branches:
     is-release-branch: false
     is-main-branch: false
     pre-release-weight: 0
+  # The per-major development branches (dev/v17, dev/v18) don't match the `develop` regex above,
+  # so without this they fall back to a branch-named label and prereleases come out as
+  # 4.1.9-dev-v17.1 instead of 4.1.9-beta.1.
+  dev-major:
+    regex: ^dev[/-]
+    mode: ContinuousDelivery
+    label: beta
+    increment: Patch
+    prevent-increment:
+      of-merged-branch: false
+    track-merge-target: true
+    source-branches: []
+    tracks-release-branches: true
+    is-release-branch: false
+    is-main-branch: false
+    pre-release-weight: 0
   rc:
     regex: ^rc$
     mode: ContinuousDelivery

--- a/Umbraco.Community.UmbNav.Core.Tests/Migrations/UmbNavLegacyModelMigrationTests.cs
+++ b/Umbraco.Community.UmbNav.Core.Tests/Migrations/UmbNavLegacyModelMigrationTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using System.Text.Json;
 using Umbraco.Community.UmbNav.Core.Migrations;
+using Umbraco.Community.UmbNav.Core.Models;
 
 namespace Umbraco.Community.UmbNav.Core.Tests.Migrations;
 
@@ -340,4 +341,117 @@ public class UmbNavLegacyModelMigrationTests
         Assert.Contains("Level 2", newValue);
         Assert.Contains("Level 3", newValue);
     }
+
+    [Fact]
+    public void TryTransformLegacyValue_WithExplicitLinkTypeAndLeftoverUdi_MapsToExternal()
+    {
+        var legacyJson = """
+            [
+                {
+                    "key": "11111111-1111-1111-1111-111111111111",
+                    "name": "Somewhere else",
+                    "itemType": "Link",
+                    "url": "https://example.com/",
+                    "udi": "umb://document/22222222222222222222222222222222"
+                }
+            ]
+            """;
+
+        UmbNavLegacyModelMigration.TryTransformLegacyValue(_loggerMock.Object, legacyJson, out var newValue);
+
+        var item = Deserialize(newValue).Single();
+        Assert.Equal(UmbNavItemType.External, item.ItemType);
+        Assert.Equal("https://example.com/", item.Url);
+        Assert.Null(item.ContentKey);
+    }
+
+    [Fact]
+    public void TryTransformLegacyValue_WithExplicitLabelTypeAndLeftoverUdi_DoesNotSetContentKey()
+    {
+        var legacyJson = """
+            [
+                {
+                    "key": "11111111-1111-1111-1111-111111111111",
+                    "name": "Just a label",
+                    "itemType": "Label",
+                    "udi": "umb://document/22222222222222222222222222222222"
+                }
+            ]
+            """;
+
+        UmbNavLegacyModelMigration.TryTransformLegacyValue(_loggerMock.Object, legacyJson, out var newValue);
+
+        var item = Deserialize(newValue).Single();
+        Assert.Equal(UmbNavItemType.Title, item.ItemType);
+        Assert.Null(item.ContentKey);
+    }
+
+    [Fact]
+    public void TryTransformLegacyValue_WithExplicitContentTypeAndUdi_KeepsContentKey()
+    {
+        var legacyJson = """
+            [
+                {
+                    "key": "11111111-1111-1111-1111-111111111111",
+                    "name": "About us",
+                    "itemType": "Content",
+                    "url": "/about-us/",
+                    "udi": "umb://document/22222222222222222222222222222222"
+                }
+            ]
+            """;
+
+        UmbNavLegacyModelMigration.TryTransformLegacyValue(_loggerMock.Object, legacyJson, out var newValue);
+
+        var item = Deserialize(newValue).Single();
+        Assert.Equal(UmbNavItemType.Document, item.ItemType);
+        Assert.Equal(Guid.Parse("22222222-2222-2222-2222-222222222222"), item.ContentKey);
+    }
+
+    [Fact]
+    public void TryTransformLegacyValue_WithUdiAndNoItemType_MapsToDocument()
+    {
+        var legacyJson = """
+            [
+                {
+                    "key": "11111111-1111-1111-1111-111111111111",
+                    "name": "About us",
+                    "udi": "umb://document/22222222222222222222222222222222"
+                }
+            ]
+            """;
+
+        UmbNavLegacyModelMigration.TryTransformLegacyValue(_loggerMock.Object, legacyJson, out var newValue);
+
+        var item = Deserialize(newValue).Single();
+        Assert.Equal(UmbNavItemType.Document, item.ItemType);
+        Assert.Equal(Guid.Parse("22222222-2222-2222-2222-222222222222"), item.ContentKey);
+    }
+
+    [Fact]
+    public void TryTransformLegacyValue_WithGenericLowercaseLinkTypeAndUdi_StillMapsToDocument()
+    {
+        // Pre-v3 data used a generic "link" item type for content picks too, where the udi is
+        // the only signal that the item points at a document.
+        var legacyJson = """
+            [
+                {
+                    "key": "11111111-1111-1111-1111-111111111111",
+                    "name": "About us",
+                    "itemType": "link",
+                    "url": "/about-us/",
+                    "udi": "umb://document/22222222222222222222222222222222"
+                }
+            ]
+            """;
+
+        UmbNavLegacyModelMigration.TryTransformLegacyValue(_loggerMock.Object, legacyJson, out var newValue);
+
+        var item = Deserialize(newValue).Single();
+        Assert.Equal(UmbNavItemType.Document, item.ItemType);
+        Assert.Equal(Guid.Parse("22222222-2222-2222-2222-222222222222"), item.ContentKey);
+    }
+
+    private static List<UmbNavItem> Deserialize(string json) =>
+        JsonSerializer.Deserialize<List<UmbNavItem>>(json)!;
 }

--- a/Umbraco.Community.UmbNav.Core.Tests/Services/UmbNavMenuBuilderServiceTests.cs
+++ b/Umbraco.Community.UmbNav.Core.Tests/Services/UmbNavMenuBuilderServiceTests.cs
@@ -374,4 +374,85 @@ public class UmbNavMenuBuilderServiceTests
         Assert.NotNull(result[0].Children!.First().Children);
         Assert.Equal("Level 2", result[0].Children!.First().Children!.First().Name);
     }
+
+    [Fact]
+    public void BuildMenu_WithExternalItemCarryingStaleContentKey_KeepsTheExternalUrl()
+    {
+        var staleContentKey = Guid.NewGuid();
+        var oldPage = new Mock<IPublishedContent>();
+        oldPage.Setup(x => x.Key).Returns(staleContentKey);
+        _contentCacheMock.Setup(x => x.GetById(staleContentKey)).Returns(oldPage.Object);
+
+        var items = new List<UmbNavItem>
+        {
+            new()
+            {
+                Name = "Somewhere else",
+                ItemType = UmbNavItemType.External,
+                Url = "https://example.com/",
+                ContentKey = staleContentKey
+            }
+        };
+
+        var result = _service.BuildMenu(items).ToList();
+
+        Assert.Single(result);
+        Assert.Equal("https://example.com/", result[0].Url);
+        Assert.Null(result[0].Content);
+        _contentCacheMock.Verify(x => x.GetById(staleContentKey), Times.Never);
+    }
+
+    [Fact]
+    public void BuildMenu_WithExternalItemCarryingStaleContentKey_ClearsTheContentKey()
+    {
+        var staleContentKey = Guid.NewGuid();
+
+        var items = new List<UmbNavItem>
+        {
+            new()
+            {
+                Name = "Somewhere else",
+                ItemType = UmbNavItemType.External,
+                Url = "https://example.com/",
+                ContentKey = staleContentKey
+            }
+        };
+
+        var result = _service.BuildMenu(items).ToList();
+
+        Assert.Null(result[0].ContentKey);
+    }
+
+    [Fact]
+    public void BuildMenu_WithTitleItemCarryingUnresolvableContentKey_KeepsItemInTheMenu()
+    {
+        var staleContentKey = Guid.NewGuid();
+        _contentCacheMock.Setup(x => x.GetById(staleContentKey)).Returns((IPublishedContent?)null);
+
+        var items = new List<UmbNavItem>
+        {
+            new() { Name = "Just a label", ItemType = UmbNavItemType.Title, ContentKey = staleContentKey }
+        };
+
+        var result = _service.BuildMenu(items).ToList();
+
+        Assert.Single(result);
+        Assert.Equal("Just a label", result[0].Name);
+    }
+
+    [Fact]
+    public void BuildMenu_WithMediaItem_StillResolvesFromTheMediaCache()
+    {
+        var mediaKey = Guid.NewGuid();
+        _mediaCacheMock.Setup(x => x.GetById(mediaKey)).Returns((IPublishedContent?)null);
+
+        var items = new List<UmbNavItem>
+        {
+            new() { Name = "A file", ItemType = UmbNavItemType.Media, ContentKey = mediaKey }
+        };
+
+        _service.BuildMenu(items).ToList();
+
+        _mediaCacheMock.Verify(x => x.GetById(mediaKey), Times.Once);
+    }
 }

--- a/Umbraco.Community.UmbNav.Core/Migrations/UmbNavLegacyModelMigration.cs
+++ b/Umbraco.Community.UmbNav.Core/Migrations/UmbNavLegacyModelMigration.cs
@@ -248,13 +248,17 @@ internal sealed class UmbNavLegacyModelMigration : AsyncPackageMigrationBase
         // Title overrides Name if set
         var name = !string.IsNullOrWhiteSpace(oldItem.Title) ? oldItem.Title : oldItem.Name;
         var udi = !string.IsNullOrWhiteSpace(oldItem.Udi) && UdiParser.TryParse(oldItem.Udi, out var parsedUdi) ? parsedUdi as GuidUdi : null;
+        var itemType = MapItemType(oldItem.ItemType);
         return new UmbNavItem
         {
             Key = oldItem.Key == Guid.Empty ? Guid.NewGuid() : oldItem.Key,
             Name = name ?? "Unknown Name Set By Migration",
             Url = oldItem.Url,
-            ItemType = MapItemType(oldItem.ItemType),
-            ContentKey = udi?.Guid,
+            ItemType = itemType,
+            // Only content backed items keep a content key. Legacy data often left a udi behind on
+            // items that were later changed to an external link or a label, and carrying that over
+            // makes the renderer resolve the old node and override the item's URL.
+            ContentKey = UmbNavItemType.Is(itemType, UmbNavItemType.Document) ? udi?.Guid : null,
             Anchor = oldItem.Anchor,
             Children = oldItem.Children?.Select(c => MapToNewModel(c, level + 1)),
             Level = oldItem.Level,
@@ -336,18 +340,36 @@ internal sealed class UmbNavLegacyModelMigration : AsyncPackageMigrationBase
         public string? ItemTypeOriginal { get; set; }
         
         [JsonIgnore]
-        public OldUmbNavItemType ItemType { 
+        public OldUmbNavItemType ItemType {
             get {
+                // An explicit type ("Link", "Content", "Label") is what the item was last saved as,
+                // so it wins over the udi. Without this, an external link that kept a stale udi from
+                // when it pointed at a page would migrate back into a content item. Matched case
+                // sensitively so the older generic "link"/"nolink" values fall through below.
+                if (Enum.TryParse<OldUmbNavItemType>(ItemTypeOriginal, ignoreCase: false, out var explicitType))
+                {
+                    return explicitType;
+                }
+
+                var hasContentUdi = !string.IsNullOrWhiteSpace(Udi) && UdiParser.TryParse(Udi, out _);
+
                 if (ItemTypeOriginal.IsNullOrWhiteSpace())
                 {
+                    // Oldest data carries no item type at all, so the udi is the only signal.
+                    if (hasContentUdi)
+                    {
+                        return OldUmbNavItemType.Content;
+                    }
+
                     return Url.IsNullOrWhiteSpace() ? OldUmbNavItemType.Label : OldUmbNavItemType.Link;
                 }
 
                 return ItemTypeOriginal.ToLowerInvariant() switch
                 {
-                    "link" => !string.IsNullOrWhiteSpace(Udi) && UdiParser.TryParse(Udi, out _) ? OldUmbNavItemType.Content : OldUmbNavItemType.Link,
+                    // The generic "link" type was used for content picks too, so the udi decides.
+                    "link" => hasContentUdi ? OldUmbNavItemType.Content : OldUmbNavItemType.Link,
                     "nolink" => OldUmbNavItemType.Label,
-                    _ => Enum.TryParse<OldUmbNavItemType>(ItemTypeOriginal, out var res) ? res : throw new ArgumentOutOfRangeException(nameof(ItemTypeOriginal), ItemTypeOriginal, null)
+                    _ => throw new ArgumentOutOfRangeException(nameof(ItemTypeOriginal), ItemTypeOriginal, null)
                 };
             }
         }

--- a/Umbraco.Community.UmbNav.Core/Services/UmbNavMenuBuilderService.cs
+++ b/Umbraco.Community.UmbNav.Core/Services/UmbNavMenuBuilderService.cs
@@ -146,6 +146,20 @@ public class UmbNavMenuBuilderService : IUmbNavMenuBuilderService
     }
 
     /// <summary>
+    /// Determines whether an item takes its URL and name from an Umbraco node.
+    /// Items that are explicitly external links or titles are never content backed, even when they
+    /// still carry a <see cref="UmbNavItem.ContentKey"/> left behind by an earlier item type.
+    /// Override this method to customize which item types resolve content.
+    /// </summary>
+    /// <param name="item">The item to check.</param>
+    /// <returns>True if the item should be resolved against the content or media cache.</returns>
+    protected virtual bool IsContentBacked(UmbNavItem item)
+    {
+        return !UmbNavItemType.Is(item.ItemType, UmbNavItemType.External)
+               && !UmbNavItemType.Is(item.ItemType, UmbNavItemType.Title);
+    }
+
+    /// <summary>
     /// Resolves content from Umbraco for Document/Media items.
     /// Sets the Content, Url, Name, and IsActive properties.
     /// Override this method to customize content resolution.
@@ -155,6 +169,14 @@ public class UmbNavMenuBuilderService : IUmbNavMenuBuilderService
     /// <returns>False if content-based item cannot be resolved (should be excluded).</returns>
     protected virtual bool ResolveContent(UmbNavItem item, Guid currentContentKey)
     {
+        if (!IsContentBacked(item))
+        {
+            // A stale key would otherwise resolve the old node and override the item's own URL,
+            // or drop the item entirely when that node is gone.
+            item.ContentKey = null;
+            return true;
+        }
+
         if (!item.ContentKey.HasValue)
         {
             return true;

--- a/Umbraco.Community.UmbNav/src/umbnav-utils.test.ts
+++ b/Umbraco.Community.UmbNav/src/umbnav-utils.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ModelEntryType, Guid } from './tokens/umbnav.token.ts';
+
+// The link picker conversions reach out to the document/media repositories for the display
+// name and published state. Those need a live backoffice, so stub the data layer.
+vi.mock('./components/umbnav-group/umbnav-group.data.ts', () => ({
+    getDocument: vi.fn(async () => ({
+        variants: [{ name: 'About us', state: 'Published' }],
+    })),
+    getMedia: vi.fn(async () => ({
+        variants: [{ name: 'Brochure' }],
+    })),
+}));
+
+const { ensureNavItemKeys, convertToUmbNavLink } = await import('./umbnav-utils.ts');
+
+const ITEM_KEY = '11111111-1111-1111-1111-111111111111' as Guid;
+const CONTENT_KEY = '22222222-2222-2222-2222-222222222222' as Guid;
+
+function navItem(overrides: Partial<ModelEntryType>): ModelEntryType {
+    return {
+        key: ITEM_KEY,
+        name: 'An item',
+        icon: null,
+        itemType: null,
+        udi: null,
+        anchor: null,
+        published: null,
+        contentKey: null,
+        children: [],
+        ...overrides,
+    };
+}
+
+// Nothing reads a `unique` property off a stored item, and the picker link's own `unique`
+// is a separate object — so anything written here just ends up as junk in the saved value.
+const host = {} as never;
+
+describe('ensureNavItemKeys', () => {
+    it('keeps the stored item type when a stale udi disagrees with it', () => {
+        const [result] = ensureNavItemKeys([
+            navItem({
+                itemType: 'External',
+                url: 'https://example.com/',
+                udi: 'umb://document/22222222222222222222222222222222',
+            }),
+        ]);
+
+        expect(result.itemType).toBe('External');
+    });
+
+    it('falls back to the udi for legacy items that have no item type', () => {
+        const [result] = ensureNavItemKeys([
+            navItem({ itemType: null, udi: 'umb://document/22222222222222222222222222222222' }),
+        ]);
+
+        expect(result.itemType).toBe('Document');
+    });
+
+    it('normalises a lowercase stored item type', () => {
+        const [result] = ensureNavItemKeys([navItem({ itemType: 'document' })]);
+
+        expect(result.itemType).toBe('Document');
+    });
+
+    it('does not write a unique property into the item', () => {
+        const [result] = ensureNavItemKeys([
+            navItem({
+                itemType: 'Document',
+                contentKey: CONTENT_KEY,
+                udi: 'umb://document/22222222222222222222222222222222',
+            }),
+        ]);
+
+        expect(result).not.toHaveProperty('unique');
+    });
+});
+
+describe('convertToUmbNavLink', () => {
+    it('builds the udi from the content key, not the nav item key', async () => {
+        const result = await convertToUmbNavLink(
+            host,
+            {
+                name: 'About us',
+                url: '/about-us/',
+                icon: 'icon-document',
+                type: 'document',
+                target: '',
+                published: true,
+                unique: CONTENT_KEY,
+                queryString: '',
+            },
+            ITEM_KEY,
+            []
+        );
+
+        expect(result.contentKey).toBe(CONTENT_KEY);
+        expect(result.udi).toBe('umb://document/22222222222222222222222222222222');
+    });
+
+    it('leaves the udi empty for an item with no content behind it', async () => {
+        const result = await convertToUmbNavLink(
+            host,
+            {
+                name: 'Just a label',
+                url: '',
+                icon: '',
+                // The link picker clears the type when the picked node is removed.
+                type: undefined as never,
+                target: '',
+                published: false,
+                unique: '',
+                queryString: '',
+            },
+            ITEM_KEY,
+            []
+        );
+
+        expect(result.itemType).toBe('Title');
+        expect(result.contentKey).toBeNull();
+        expect(result.udi).toBeNull();
+    });
+});

--- a/Umbraco.Community.UmbNav/src/umbnav-utils.ts
+++ b/Umbraco.Community.UmbNav/src/umbnav-utils.ts
@@ -174,8 +174,10 @@ export async function convertToUmbNavLink(
             itemType: itemType,
             target: item.target,
             published: isPublished,
+            // The udi identifies the picked node, so it is built from the content key. Items with
+            // nothing behind them (external links, titles) get no udi at all.
             // @ts-ignore
-            udi: item.type === 'external' ? '' : `umb://${item.type}/${key.replace(/-/g, '')}`,
+            udi: linkId ? `umb://${item.type}/${linkId.replace(/-/g, '')}` : null,
             contentKey: linkId,
             anchor: item.queryString,
             customClasses: menuItem?.customClasses ?? '',
@@ -239,15 +241,21 @@ function normalizeItemType(value: UmbNavLinkPickerLinkType | null | undefined): 
     }
 }
 
+function itemTypeFromUdi(udi: ModelEntryType['udi']): UmbNavLinkPickerLinkType | null | undefined {
+    if (udi == null) return undefined;
+    if (udi.startsWith('umb://document/')) return 'Document';
+    if (udi.startsWith('umb://media/')) return 'Media';
+    return undefined;
+}
+
 export function ensureNavItemKeys(value: ModelEntryType[]): ModelEntryType[] {
     return value.map(item => ({
         ...item,
         key: item.key ?? (uuidv4() as Guid),
-        unique: item.udi != null && (item.udi.startsWith('umb://document/') || item.udi.startsWith('umb://media/')) ? item.key : undefined,
-        itemType: normalizeItemType(
-            item.udi != null && item.udi.startsWith('umb://document/') ? 'Document' :
-            item.udi != null && item.udi.startsWith('umb://media/') ? 'Media' : item.itemType
-        ),
+        // The stored item type is what the item was last saved as, so it wins. The udi is only a
+        // fallback for older data saved before the item type was persisted — reading it first would
+        // send an item that has since been retyped straight back to Document.
+        itemType: normalizeItemType(item.itemType || itemTypeFromUdi(item.udi)),
         // Always ensure children is an array so nested sorters can initialize
         children: Array.isArray(item.children) ? ensureNavItemKeys(item.children) : []
     }));


### PR DESCRIPTION
Fixes #204.

## The bug

Editing a nav item so it points somewhere new leaves the site rendering the **old** link. Clearing Umbraco's cache doesn't help; deleting and re-adding the item does.

It isn't a cache problem — the value converter uses the default `PropertyCacheLevel.Snapshot`, which is per request. The rendered URL was driven by `ContentKey` alone, with `ItemType` ignored:

- `UmbNavMenuBuilderService.ResolveContent` resolved *any* item carrying a `ContentKey` and overwrote `item.Url` with the node's URL, even when the item was now `External` or `Title`.
- `UmbNavItemExtensions.Url()` then prefers `item.Content` over `item.Url`, so the TagHelper and `GetLinkHtml()` both emitted the old page's URL.

Same root cause, second failure mode: when the stale key pointed at content that had since been unpublished or deleted, `ResolveContent` returned `false` and the item **disappeared from the menu**.

## The fix — rendering

**`UmbNavMenuBuilderService`** — new `protected virtual bool IsContentBacked(UmbNavItem)`, false for `External` and `Title`. `ResolveContent` returns early for those and clears the leftover `ContentKey` instead of resolving it. Clearing the key also stops `IsActive()` marking an external link active on the page it used to point at.

## The fix — migration

**`UmbNavLegacyModelMigration`** — one confirmed source of the stale keys:

- `ContentKey = udi?.Guid` ran for every item type, so a legacy label with a leftover udi migrated into a ghost content item. It's now only set for `Document`.
- An explicit legacy item type (`"Link"` / `"Content"` / `"Label"`) now wins over the udi. Previously `"Link"` + a stale udi was reclassified as `Content`, so a v3 external link that kept a udi from when it pointed at a page migrated into a `Document` item aimed at the old page. The older generic lowercase `"link"` / `"nolink"` values keep the udi heuristic, since those were used for content picks too.
- Fixed the no-`itemType` fallback: a udi with no url fell through to `Label` (and still got a content key); it now maps to `Content`.

## The fix — editor (second commit)

The same class of bug on the client, found while tracing the above. Latent today rather than user-visible, so shout if you'd rather it went in its own PR.

- `convertToUmbNavLink` built the udi from the **nav item's own key** instead of the content key, so every document and media item was saved with a udi identifying nothing, and an item with no link got `umb://undefined/...`. It's now built from the content key, and left null when there is nothing behind the item.
- `ensureNavItemKeys` read that udi back on load and used it to **override the stored `itemType`**, which would send a retyped item straight back to `Document`. The stored item type now wins; the udi is consulted only for older data saved before the item type was persisted.
- Dropped the `unique` property `ensureNavItemKeys` wrote into every stored item — nothing reads it, and it held the nav item key rather than the content key its name implies.

## Tests

15 regression tests, each watched failing against the old code first.

`UmbNavMenuBuilderServiceTests` — external item with a stale key keeps its URL and never touches the content cache; the stale key is cleared; a `Title` item with an unresolvable key stays in the menu; a `Media` item still resolves from the media cache.

`UmbNavLegacyModelMigrationTests` — explicit `Link` + leftover udi maps to `External` with no content key; explicit `Label` + leftover udi gets no content key; explicit `Content` + udi keeps its key; udi with no item type maps to `Document`; lowercase `"link"` + udi still maps to `Document`. The last three guard against over-correcting.

`umbnav-utils.test.ts` (new Vitest file) — a stored item type survives a disagreeing udi; the udi is still a fallback when there's no item type; lowercase item types still normalise; no `unique` property is written; the udi is built from the content key; no udi for an item with no content.

`dotnet test`: 151 passed, 0 failed. `npm run test:unit`: 15 passed, 0 failed. `npm run build` (tsc + vite) clean.

The Playwright E2E suite needs a running site, so it hasn't been run here — worth a pass before merge, though no spec touches `udi` or `unique`.

## Worth a second opinion

The migration change rests on an inference I couldn't verify from this repo: that v3 wrote `"Link"` / `"Content"` / `"Label"` explicitly and left stale udis behind on retyped items. The migration's own `"link"` + udi rule is the evidence for it. If v3 also wrote lowercase `"link"` for external links, that branch needs the same treatment — and there'd be no signal left to distinguish them but the URL shape.

The reporter's steps ("change the type to label", "set to link and enter an external url") describe a link editor with a type selector, which is v3's dialog rather than the v17 link picker — so it's worth confirming their package version. The renderer fix applies either way; the migration fix is what carries v3-era data across cleanly.

The `udi` → `contentKey` row in `Docs/umbnav-documentation/upgrading.md` needs the same "content items only" note, but Docs is a submodule so that's a separate change in the docs repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
